### PR TITLE
Fix: getTitle() produces the error - trim() expects string as parameter

### DIFF
--- a/src/Adapter/Windows.php
+++ b/src/Adapter/Windows.php
@@ -157,7 +157,7 @@ class Windows extends Virtual
             return '';
         }
 
-        return trim($output, "\r\n");
+        return trim(implode('', $output), "\r\n");
     }
 
     /**


### PR DESCRIPTION
exec() returns array as $output, we were trying to use it as string.
