### PR TITLE
Use the console adapter to write instead of echo.

### DIFF
--- a/src/Prompt/Char.php
+++ b/src/Prompt/Char.php
@@ -94,10 +94,10 @@ class Char extends AbstractPrompt
         $char = $this->getConsole()->readChar($mask);
 
         if ($this->echo) {
-            echo trim($char)."\n";
+            $this->getConsole()->writeLine(trim($char));
         } else {
             if ($this->promptText) {
-                echo "\n";  // skip to next line but only if we had any prompt text
+                $this->getConsole()->writeLine();  // skip to next line but only if we had any prompt text
             }
         }
 


### PR DESCRIPTION
The Char prompt was just echoing directly rather than using the writeLine() method from the Console adapter.  This was done correctly in the Select prompt already.  Using echo can make testing more difficult because you can't mock the write away and instead of to do hacky things like using output buffering.
