### PR TITLE
Forwards-compatibility with zend-stdlib/servicemanager 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,19 @@ matrix:
         - EXECUTE_TEST_COVERALLS=true
     - php: 7
     - php: hhvm 
-  allow_failures:
+    - php: 5.5
+      env:
+        - EXCLUDE_VALIDATOR=true
+    - php: 5.6
+      env:
+        - EXCLUDE_VALIDATOR=true
     - php: 7
+      env:
+        - EXCLUDE_VALIDATOR=true
+    - php: hhvm 
+      env:
+        - EXCLUDE_VALIDATOR=true
+  allow_failures:
     - php: hhvm
 
 notifications:
@@ -34,6 +45,7 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - composer self-update
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
+  - if [[ $EXCLUDE_VALIDATOR == 'true' ]]; then composer remove --dev --no-update zendframework/zend-validator ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/composer.json
+++ b/composer.json
@@ -7,26 +7,15 @@
         "console"
     ],
     "homepage": "https://github.com/zendframework/zend-console",
-    "autoload": {
-        "psr-4": {
-            "Zend\\Console\\": "src/"
-        }
-    },
-    "require": {
-        "php": ">=5.5",
-        "zendframework/zend-stdlib": "~2.5"
-    },
-    "suggest": {
-        "zendframework/zend-validator": "To support DefaultRouteMatcher usage",
-        "zendframework/zend-filter": "To support DefaultRouteMatcher usage",
-        "zendframework/zend-text": "Add text based components"
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "extra": {
         "branch-alias": {
             "dev-master": "2.5-dev",
             "dev-develop": "2.6-dev"
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "Zend\\Console\\": "src/"
         }
     },
     "autoload-dev": {
@@ -34,11 +23,19 @@
             "ZendTest\\Console\\": "test/"
         }
     },
+    "require": {
+        "php": "^5.5 || ^7.0",
+        "zendframework/zend-stdlib": "^2.7 || ^3.0"
+    },
     "require-dev": {
         "fabpot/php-cs-fixer": "1.7.*",
-        "phpunit/PHPUnit": "~4.0",
-        "zendframework/zend-filter": "~2.5",
-        "zendframework/zend-json": "~2.5",
-        "zendframework/zend-validator": "~2.5"
+        "phpunit/PHPUnit": "^4.0",
+        "zendframework/zend-filter": "^2.6",
+        "zendframework/zend-json": "^2.6",
+        "zendframework/zend-validator": "^2.5"
+    },
+    "suggest": {
+        "zendframework/zend-filter": "To support DefaultRouteMatcher usage",
+        "zendframework/zend-validator": "To support DefaultRouteMatcher usage"
     }
 }

--- a/test/RouteMatcher/DefaultRouteMatcherTest.php
+++ b/test/RouteMatcher/DefaultRouteMatcherTest.php
@@ -11,6 +11,8 @@
 namespace ZendTest\Console\RouteMatcher;
 
 use Zend\Console\RouteMatcher\DefaultRouteMatcher;
+use Zend\Validator\Digits;
+use Zend\Validator\StringLength;
 
 /**
  * @category   Zend
@@ -1253,12 +1255,23 @@ class DefaultRouteMatcherTest extends \PHPUnit_Framework_TestCase
 
     public function routeValidatorsProvider()
     {
+        if (! class_exists(Digits::class)) {
+            return [
+                'do-not-run' => [
+                    '<string> <number>',
+                    [],
+                    ['foobar', '12345'],
+                    true,
+                ],
+            ];
+        }
+
         return [
             'validators-valid' => [
                 '<string> <number>',
                 [
-                    'string' => new \Zend\Validator\StringLength(['min' => 5, 'max' => 12]),
-                    'number' => new \Zend\Validator\Digits()
+                    'string' => new StringLength(['min' => 5, 'max' => 12]),
+                    'number' => new Digits()
                 ],
                 ['foobar', '12345'],
                 true
@@ -1266,8 +1279,8 @@ class DefaultRouteMatcherTest extends \PHPUnit_Framework_TestCase
             'validators-invalid' => [
                 '<string> <number>',
                 [
-                    'string' => new \Zend\Validator\StringLength(['min' => 5, 'max' => 12]),
-                    'number' => new \Zend\Validator\Digits()
+                    'string' => new StringLength(['min' => 5, 'max' => 12]),
+                    'number' => new Digits()
                 ],
                 ['foo', '12345'],
                 false
@@ -1275,8 +1288,8 @@ class DefaultRouteMatcherTest extends \PHPUnit_Framework_TestCase
             'validators-invalid2' => [
                 '<number> <string>',
                 [
-                    'string' => new \Zend\Validator\StringLength(['min' => 5, 'max' => 12]),
-                    'number' => new \Zend\Validator\Digits()
+                    'string' => new StringLength(['min' => 5, 'max' => 12]),
+                    'number' => new Digits()
                 ],
                 ['foozbar', 'not_digits'],
                 false
@@ -1294,6 +1307,14 @@ class DefaultRouteMatcherTest extends \PHPUnit_Framework_TestCase
      */
     public function testParamsCanBeValidated($routeDefinition, $validators, $arguments, $shouldMatch)
     {
+        if (! class_exists(Digits::class)) {
+            $this->markTestSkipped(sprintf(
+                '%s is skipped due to a dependency on zend-validator; update once that component '
+                . 'is forwards-compatible with zend-stdlib and zend-servicemanager v3',
+                __METHOD__
+            ));
+        }
+
         $matcher = new DefaultRouteMatcher($routeDefinition, [], [], [], null, $validators);
         $match = $matcher->match($arguments);
         if ($shouldMatch === false) {


### PR DESCRIPTION
Updates dependencies to versions that are forwards compatible with zend-stdlib and zend-servicemanager v3. Since zend-validator is not yet up-to-date, the travis configuration has been updated to add additional jobs that remove that development dependency in order to test the zend-stdlib/zend-servicemanager integrations.

`DefaultRouteMatcherTest` was updated to conditionally skip tests that utilize validators, based on whether or not the classes exist.
