### PR TITLE
Re-enable validator tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,6 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - composer self-update
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
-  - if [[ $EXCLUDE_VALIDATOR == 'true' ]]; then composer remove --dev --no-update zendframework/zend-validator ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "phpunit/PHPUnit": "^4.0",
         "zendframework/zend-filter": "^2.6",
         "zendframework/zend-json": "^2.6",
-        "zendframework/zend-validator": "^2.5"
+        "zendframework/zend-validator": "^2.6"
     },
     "suggest": {
         "zendframework/zend-filter": "To support DefaultRouteMatcher usage",

--- a/test/RouteMatcher/DefaultRouteMatcherTest.php
+++ b/test/RouteMatcher/DefaultRouteMatcherTest.php
@@ -1307,14 +1307,6 @@ class DefaultRouteMatcherTest extends \PHPUnit_Framework_TestCase
      */
     public function testParamsCanBeValidated($routeDefinition, $validators, $arguments, $shouldMatch)
     {
-        if (! class_exists(Digits::class)) {
-            $this->markTestSkipped(sprintf(
-                '%s is skipped due to a dependency on zend-validator; update once that component '
-                . 'is forwards-compatible with zend-stdlib and zend-servicemanager v3',
-                __METHOD__
-            ));
-        }
-
         $matcher = new DefaultRouteMatcher($routeDefinition, [], [], [], null, $validators);
         $match = $matcher->match($arguments);
         if ($shouldMatch === false) {


### PR DESCRIPTION
Now that zend-validator has a stable, forwards compatible version, we can re-enable tests against it on Travis.
