### PR TITLE
Remove fast_finish flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ env:
     - secure: "can3MouUZEPZnJUSetVwM7dZ4Wm876zomJnY2PpbWheZm1vE9nEFIVntk5oL4GJfHd2rr8l3Ot2o/IeD//8Zvinf0lVqaX8sPgq8xLcKSozeIiSzblbGKVCwDHZO5LnKTyXo+dWgKRziajBd4A6cNeO1s7srrYlroF/G4gajf29KAXJhQ8b2JtwIgjpK/n7M9pACBwzDs+5BcGfKLh6KhNJQv41tTzH69+9wMV1Lsn2ksA/CJoOGWKO0EJyu7FcXh7PugfqfmW988074WnJ57pPsOToLrYUHtaIh/6iv6S9/yYXqYw+Pdjkc3SJvWRfnAvvOaASkRsQT2jD3NknLrK0tbu7Z0EWfHYdTpAqsX9S0u/vAeyQKxG/5SotWwLH9zUxgoPgZ4rnVZwoVkOxv1rzOD/28CNToaQZ/GDQTsaEvLNg51TGCMmmyJDzK4p7WSVxLKmiM106SGj/H3brmTr0l32u8itvyfyZaJwIk7aQP/xIFgqA/qpApd/ykSTRs7u8CIj1PhdRP6FyYwUc+xn8d9Ylat1NoKJI4P6BajuUEPCij8joowb0ep05DgIMGqgU8aHuCBeIz0RiWQrbn4V9pzchVFfmd5KCUV87hoCsXYo1RNVDW4kpaOj7OG9R1tKSHVmyHmmKgy8dElYQrDIQDDgDEWFUxzE9gMQb4vQM="
 
 matrix:
-  fast_finish: true
   include:
     - php: 5.5
       env:


### PR DESCRIPTION
It has been confirmed that the fast_finish flag is responsible for triggering multiple build notifications on #zftalk.dev.
