### PR TITLE
Add consistency to method chaining DocBlocks

### DIFF
--- a/src/Getopt.php
+++ b/src/Getopt.php
@@ -301,7 +301,7 @@ class Getopt
      *
      * @param  array $argv
      * @throws Exception\InvalidArgumentException When not given an array as parameter
-     * @return self
+     * @return Getopt Provides a fluent interface
      */
     public function addArguments($argv)
     {
@@ -319,7 +319,7 @@ class Getopt
      *
      * @param  array $argv
      * @throws Exception\InvalidArgumentException When not given an array as parameter
-     * @return self
+     * @return Getopt Provides a fluent interface
      */
     public function setArguments($argv)
     {
@@ -337,7 +337,7 @@ class Getopt
      * the behavior of Zend\Console\Getopt.
      *
      * @param  array $getoptConfig
-     * @return self
+     * @return Getopt Provides a fluent interface
      */
     public function setOptions($getoptConfig)
     {
@@ -356,7 +356,7 @@ class Getopt
      *
      * @param  string $configKey
      * @param  string $configValue
-     * @return self
+     * @return Getopt Provides a fluent interface
      */
     public function setOption($configKey, $configValue)
     {
@@ -371,7 +371,7 @@ class Getopt
      * These are appended to the rules defined when the constructor was called.
      *
      * @param  array $rules
-     * @return self
+     * @return Getopt Provides a fluent interface
      */
     public function addRules($rules)
     {
@@ -600,7 +600,7 @@ class Getopt
      *
      * @param  array $aliasMap
      * @throws Exception\ExceptionInterface
-     * @return self
+     * @return Getopt Provides a fluent interface
      */
     public function setAliases($aliasMap)
     {
@@ -630,7 +630,7 @@ class Getopt
      * mapping option name (short or long) to the help string.
      *
      * @param  array $helpMap
-     * @return self
+     * @return Getopt Provides a fluent interface
      */
     public function setHelp($helpMap)
     {
@@ -651,7 +651,7 @@ class Getopt
      * Also find option parameters, and remaining arguments after
      * all options have been parsed.
      *
-     * @return self
+     * @return Getopt Provides a fluent interface
      */
     public function parse()
     {
@@ -696,13 +696,13 @@ class Getopt
     /**
      * @param string   $option   The name of the property which, if present, will call the passed
      *                           callback with the value of this parameter.
-     * @param callable $callback The callback that will be called for this option. The first
+     * @param \Closure $callback The callback that will be called for this option. The first
      *                           parameter will be the value of getOption($option), the second
      *                           parameter will be a reference to $this object. If the callback returns
      *                           false then an Exception\RuntimeException will be thrown indicating that
      *                           there is a parse issue with this option.
      *
-     * @return self
+     * @return Getopt Provides a fluent interface
      */
     public function setOptionCallback($option, \Closure $callback)
     {

--- a/src/Request.php
+++ b/src/Request.php
@@ -76,7 +76,7 @@ class Request extends Message implements RequestInterface
      * Exchange parameters object
      *
      * @param \Zend\Stdlib\Parameters $params
-     * @return Request
+     * @return Request Provides a fluent interface
      */
     public function setParams(Parameters $params)
     {
@@ -127,7 +127,7 @@ class Request extends Message implements RequestInterface
      * primary API for value setting, for that see env())
      *
      * @param \Zend\Stdlib\Parameters $env
-     * @return \Zend\Console\Request
+     * @return Request Provides a fluent interface
      */
     public function setEnv(Parameters $env)
     {

--- a/src/Response.php
+++ b/src/Response.php
@@ -33,8 +33,8 @@ class Response extends Message implements ResponseInterface
     /**
      * Set the error level that will be returned to shell.
      *
-     * @param int   $errorLevel
-     * @return Response
+     * @param int $errorLevel
+     * @return Response Provides a fluent interface
      */
     public function setErrorLevel($errorLevel)
     {
@@ -59,7 +59,7 @@ class Response extends Message implements ResponseInterface
     /**
      * Send content
      *
-     * @return Response
+     * @return Response Provides a fluent interface
      * @deprecated
      */
     public function sendContent()


### PR DESCRIPTION
As discussed in [fluent interface return type vs return self #7193](https://github.com/zendframework/zendframework/issues/7193), this changes remove occurrences of class names and self keyword from the DocBlocks
