### PR TITLE
Add catch-all route parameters.

### DIFF
--- a/doc/book/routes.md
+++ b/doc/book/routes.md
@@ -104,6 +104,7 @@ Routing strings consist of one or more of the following:
 - [Positional value parameters](#positional-value-parameters) (e.g. `create <modelName> [<destination>]`)
 - [Value flags](#value-flag-parameters) (e.g. `--name=NAME [--method=METHOD]`)
 - [Named literal alternative groups](#grouping-literal-alternatives) (e.g., `(all|some|none):filter`)
+- [Catch-all parameters](#catch-all-parameters) (e.g. `[...params]`)
 
 ### Literal parameters
 
@@ -395,6 +396,27 @@ switch ($params['filter']) {
 }
 ```
 
+### Catch-all Parameters
+
+When a route may receive a variable number of parameters (for example, to
+implement a feature like echo, or to process an arbitrary list of files),
+you can use a catch-all parameter to collect all parameters that are not
+matched by another part of the route. These collected values can be accessed
+as a single parameter (whose name is defined in the route) containing an array.
+
+When used, the catch-all parameter must come after all positional value
+parameters. You can only use one catch-all parameter per route.
+
+Example:
+
+```
+say [loudly|softly]:volume [...words]
+```
+
+If the user entered the command line `say loudly I am here`, the 'volume'
+parameter would contain `'loudly'` and the 'words' parameter would contain
+`['I', 'am', 'here']`.
+
 ## Console routes cheat-sheet
 
 Param type                        | Example route definition    | Explanation
@@ -424,3 +446,7 @@ Long flags group                  | `foo (--bar|--baz):myParam` | "foo", "bar" o
 Long optional flags group         | `foo [--bar|--baz]:myParam` | "foo", optional "bar" or "baz" flag before or after (as "myParam" param)
 Short flags group                 | `foo (-b|-z):myParam`       | "foo", "-b" or "-z" flag before or after (stored as "myParam" param)
 Short optional flags group        | `foo [-b|-z]:myParam`       | "foo", optional "-b" or "-z" flag before or after (stored as "myParam" param)
+**Catch-all parameters**          |                             |
+Simple catch-all                  | `foo [...bar]`              | "foo" followed by any number of params, stored as array in "bar" param
+Literal alternative w/ catch-all  | `foo (bar|baz) [...xyzzy]`  | "foo" followed by "bar" or "baz", with extra input stored as "xyzzy" param
+Value param w/ catch-all          | `foo <bar> [...baz]`        | "foo", with first parameter stored as "bar" and remainder stored as "baz"

--- a/doc/book/routes.md
+++ b/doc/book/routes.md
@@ -423,30 +423,30 @@ Param type                        | Example route definition    | Explanation
 :---                              | :---                        | :---
 **Literal params**                |                             |
 Literal                           | `foo bar`                   | "foo" followed by "bar"
-Literal alternative               | `foo (bar|baz)`             | "foo" followed by "bar" or "baz"
+Literal alternative               | `foo (bar\|baz)`             | "foo" followed by "bar" or "baz"
 Literal, optional                 | `foo [bar]`                 | "foo", optional "bar"
-Literal, optional alternative     | `foo [bar|baz]`             | "foo", optional "bar" or "baz"
+Literal, optional alternative     | `foo [bar\|baz]`             | "foo", optional "bar" or "baz"
 **Flags**                         |                             |
 Flag long                         | `foo --bar`                 | "foo" as first parameter, "--bar" flag before or after
 Flag long, optional               | `foo [--bar]`               | "foo" as first parameter, optional "--bar" flag before or after
-Flag long, optional, alternative  | `foo [--bar|--baz]`         | "foo" as first parameter, optional "--bar" or "--baz", before or after
+Flag long, optional, alternative  | `foo [--bar\|--baz]`         | "foo" as first parameter, optional "--bar" or "--baz", before or after
 Flag short                        | `foo -b`                    | "foo" as first parameter, "-b" flag before or after
 Flag short, optional              | `foo [-b]`                  | "foo" as first parameter, optional "-b" flag before or after
 Flag short, optional, alternative | `foo [-b|-z]`               | "foo" as first parameter, optional "-b" or "-z", before or after
-Flag long/short alternative       | `foo [--bar|-b]`            | "foo" as first parameter, optional "--bar" or "-b" before or after
+Flag long/short alternative       | `foo [--bar\|-b]`            | "foo" as first parameter, optional "--bar" or "-b" before or after
 **Value parameters**              |                             |
 Value positional param            | `foo <bar>`                 | "foo" followed by any text (stored as "bar" param)
 Value positional param, optional  | `foo [<bar>]`               | "foo", optionally followed by any text (stored as "bar" param)
 Value Flag                        | `foo --bar=`                | "foo" as first parameter, "--bar" with a value, before or after
 Value Flag, optional              | `foo [--bar=]`              | "foo" as first parameter, optionally "--bar" with a value, before or after
 **Parameter groups**              |                             |
-Literal params group              | `foo (bar|baz):myParam`     | "foo" followed by "bar" or "baz" (stored as "myParam" param)
-Literal optional params group     | `foo [bar|baz]:myParam`     | "foo" followed by optional "bar" or "baz" (stored as "myParam" param)
-Long flags group                  | `foo (--bar|--baz):myParam` | "foo", "bar" or "baz" flag before or after (stored as "myParam" param)
-Long optional flags group         | `foo [--bar|--baz]:myParam` | "foo", optional "bar" or "baz" flag before or after (as "myParam" param)
-Short flags group                 | `foo (-b|-z):myParam`       | "foo", "-b" or "-z" flag before or after (stored as "myParam" param)
-Short optional flags group        | `foo [-b|-z]:myParam`       | "foo", optional "-b" or "-z" flag before or after (stored as "myParam" param)
+Literal params group              | `foo (bar\|baz):myParam`     | "foo" followed by "bar" or "baz" (stored as "myParam" param)
+Literal optional params group     | `foo [bar\|baz]:myParam`     | "foo" followed by optional "bar" or "baz" (stored as "myParam" param)
+Long flags group                  | `foo (--bar\|--baz):myParam` | "foo", "bar" or "baz" flag before or after (stored as "myParam" param)
+Long optional flags group         | `foo [--bar\|--baz]:myParam` | "foo", optional "bar" or "baz" flag before or after (as "myParam" param)
+Short flags group                 | `foo (-b\|-z):myParam`       | "foo", "-b" or "-z" flag before or after (stored as "myParam" param)
+Short optional flags group        | `foo [-b\|-z]:myParam`       | "foo", optional "-b" or "-z" flag before or after (stored as "myParam" param)
 **Catch-all parameters**          |                             |
 Simple catch-all                  | `foo [...bar]`              | "foo" followed by any number of params, stored as array in "bar" param
-Literal alternative w/ catch-all  | `foo (bar|baz) [...xyzzy]`  | "foo" followed by "bar" or "baz", with extra input stored as "xyzzy" param
+Literal alternative w/ catch-all  | `foo (bar\|baz) [...xyzzy]`  | "foo" followed by "bar" or "baz", with extra input stored as "xyzzy" param
 Value param w/ catch-all          | `foo <bar> [...baz]`        | "foo", with first parameter stored as "bar" and remainder stored as "baz"

--- a/src/RouteMatcher/DefaultRouteMatcher.php
+++ b/src/RouteMatcher/DefaultRouteMatcher.php
@@ -428,6 +428,14 @@ class DefaultRouteMatcher implements RouteMatcherInterface
                     'alternatives'  => $options,
                     'hasValue'      => false,
                 ];
+            } elseif (preg_match('/\G\[ *?\.\.\.(?P<name>[a-zA-Z][a-zA-Z0-9\_\-\:]*?) *?\](?: +|$)/s', $def, $m, 0, $pos)) {
+                $item = [
+                    'name'       => $m['name'],
+                    'literal'    => false,
+                    'required'   => false,
+                    'catchAll'   => true,
+                    'hasValue'   => true,
+                ];
             } else {
                 throw new Exception\InvalidArgumentException(
                     'Cannot understand Console route at "' . substr($def, $pos) . '"'
@@ -486,9 +494,18 @@ class DefaultRouteMatcher implements RouteMatcherInterface
          * Extract positional and named parts
          */
         $positional = $named = [];
+        $catchAll = null;
         foreach ($this->parts as &$part) {
-            if ($part['positional']) {
+            if (isset($part['positional']) && $part['positional']) {
                 $positional[] = &$part;
+            } elseif (isset($part['catchAll']) && $part['catchAll']) {
+                if (null !== $catchAll) {
+                    throw new Exception\InvalidArgumentException(
+                        'Cannot define more than one catchAll parameter'
+                    );
+                }
+                $catchAll = &$part;
+                $matches[$catchAll['name']] = [];
             } else {
                 $named[] = &$part;
             }
@@ -653,7 +670,9 @@ class DefaultRouteMatcher implements RouteMatcherInterface
          */
         foreach ($params as $param) {
             if (preg_match('#^\-+#', $param)) {
-                return; // there is an unrecognized flag
+                if (null === $catchAll) {
+                    return; // there is an unrecognized flag
+                }
             }
         }
 
@@ -734,7 +753,13 @@ class DefaultRouteMatcher implements RouteMatcherInterface
          * Check if we have consumed all positional parameters
          */
         if ($argPos < count($params)) {
-            return; // there are extraneous params that were not consumed
+            if (null !== $catchAll) {
+                for ($i = $argPos; $i < count($params); $i++) {
+                    $matches[$catchAll['name']][] = $params[$i];
+                }
+            } else {
+                return; // there are extraneous params that were not consumed
+            }
         }
 
         /*

--- a/test/RouteMatcher/DefaultRouteMatcherTest.php
+++ b/test/RouteMatcher/DefaultRouteMatcherTest.php
@@ -10,6 +10,7 @@
 
 namespace ZendTest\Console\RouteMatcher;
 
+use Zend\Console\Exception\InvalidArgumentException;
 use Zend\Console\RouteMatcher\DefaultRouteMatcher;
 use Zend\Validator\Digits;
 use Zend\Validator\StringLength;
@@ -1416,5 +1417,21 @@ class DefaultRouteMatcherTest extends \PHPUnit_Framework_TestCase
         new DefaultRouteMatcher('<foo>', [], [], [], [], [
             new \stdClass()
         ]);
+    }
+
+    public function testIllegalRouteDefinitions()
+    {
+        $badRoutes = [
+            '[...catchall1] [...catchall2]' => 'Cannot define more than one catchAll parameter',
+            '[...catchall] [positional]' => 'Positional parameters must come before catchAlls',
+        ];
+        foreach ($badRoutes as $route => $msg) {
+            try {
+                new DefaultRouteMatcher($route);
+                $this->fail('Expected exception (' . $msg . ') not thrown!');
+            } catch (InvalidArgumentException $ex) {
+                $this->assertEquals($msg, $ex->getMessage());
+            }
+        }
     }
 }

--- a/test/RouteMatcher/DefaultRouteMatcherTest.php
+++ b/test/RouteMatcher/DefaultRouteMatcherTest.php
@@ -932,6 +932,16 @@ class DefaultRouteMatcherTest extends \PHPUnit_Framework_TestCase
                 ['baz'],
                 null,
             ],
+            'catchall' => [
+                'catchall [...params]',
+                ['catchall', 'foo', 'bar', '--xyzzy'],
+                ['params' => ['foo', 'bar', '--xyzzy']],
+            ],
+            'catchall-with-flag' => [
+                'catchall [--flag] [...params]',
+                ['catchall', 'foo', '--flag', 'bar', '--xyzzy'],
+                ['params' => ['foo', 'bar', '--xyzzy'], 'flag' => true],
+            ],
         ];
     }
 
@@ -953,10 +963,17 @@ class DefaultRouteMatcherTest extends \PHPUnit_Framework_TestCase
             $this->assertInternalType('array', $match);
 
             foreach ($params as $key => $value) {
+                if ($value === null) {
+                    $msg = "Param $key is not present";
+                } elseif (is_array($value)) {
+                    $msg = "Values in array $key do not match";
+                } else {
+                    $msg = "Param $key is present and is equal to $value";
+                }
                 $this->assertEquals(
                     $value,
                     isset($match[$key])?$match[$key]:null,
-                    $value === null ? "Param $key is not present" : "Param $key is present and is equal to $value"
+                    $msg
                 );
             }
         }


### PR DESCRIPTION
- You can now use [...params] to collect all "left over" parameters to a single array.
- Useful for implementing routes with arbitrary parameter counts (e.g. reimplementing "echo" or acting on an arbitrary list of files); also useful for situations where complex validation needs to be applied in the controller.
- This provides a solution to the long-standing unresolved issue at https://github.com/zendframework/zendframework/issues/6195

I'd love to see this functionality merged to the project, as the ability to deal with arbitrary parameter lists is important to me. However, I am not wedded to this exact approach and would be happy to discuss alternative approaches if others have different preferences.
