### PR TITLE
spelling fixes

### DIFF
--- a/test/RouteMatcher/DefaultRouteMatcherTest.php
+++ b/test/RouteMatcher/DefaultRouteMatcherTest.php
@@ -631,7 +631,7 @@ class DefaultRouteMatcherTest extends \PHPUnit_Framework_TestCase
                     'baz' => true
                 ]
             ],
-            // group with group name diferent than options (short)
+            // group with group name different than options (short)
             'group-1' => [
                 'group [-t|--test]:testgroup',
                 ['group', '-t'],
@@ -640,7 +640,7 @@ class DefaultRouteMatcherTest extends \PHPUnit_Framework_TestCase
                     'testgroup' => true,
                 ]
             ],
-            // group with group name diferent than options (long)
+            // group with group name different than options (long)
             'group-2' => [
                 'group [-t|--test]:testgroup',
                 ['group', '--test'],


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( http://www.misfix.org, https://github.com/ka7/misspell_fixer ). Any upcoming License changes (e.g. GPL2 to GPL3+) are hereby granted.