### PR TITLE
Missing infos on zend-mvc-console

### DIFF
--- a/docs/book/intro.md
+++ b/docs/book/intro.md
@@ -1,5 +1,8 @@
 # Introduction to zend-console
 
+## Deprecated
+Both the zend-console an the [zend-mvc-console](https://docs.zendframework.com/zend-mvc-console/) components will likely not be maintained long-term, as there are more complete implementations available elsewhere. We strongly urge developers to start migrating their console tooling to use other libraries, such as [symfony/console](https://github.com/symfony/console).
+
 zend-console provides both generic support for routable console applications, as
 well as the basis for adding console support to zend-mvc-based applications.
 

--- a/docs/book/intro.md
+++ b/docs/book/intro.md
@@ -1,6 +1,7 @@
 # Introduction to zend-console
 
 > ### Deprecated
+>
 > Both the zend-console and the [zend-mvc-console](https://docs.zendframework.com/zend-mvc-console/) components will likely not be maintained long-term, as there are more complete implementations available elsewhere. We strongly urge developers to start migrating their console tooling to use other libraries, such as [symfony/console](https://github.com/symfony/console).
 
 zend-console provides both generic support for routable console applications, as

--- a/docs/book/intro.md
+++ b/docs/book/intro.md
@@ -1,7 +1,7 @@
 # Introduction to zend-console
 
-## Deprecated
-Both the zend-console an the [zend-mvc-console](https://docs.zendframework.com/zend-mvc-console/) components will likely not be maintained long-term, as there are more complete implementations available elsewhere. We strongly urge developers to start migrating their console tooling to use other libraries, such as [symfony/console](https://github.com/symfony/console).
+> ### Deprecated
+> Both the zend-console an the [zend-mvc-console](https://docs.zendframework.com/zend-mvc-console/) components will likely not be maintained long-term, as there are more complete implementations available elsewhere. We strongly urge developers to start migrating their console tooling to use other libraries, such as [symfony/console](https://github.com/symfony/console).
 
 zend-console provides both generic support for routable console applications, as
 well as the basis for adding console support to zend-mvc-based applications.

--- a/docs/book/intro.md
+++ b/docs/book/intro.md
@@ -1,7 +1,7 @@
 # Introduction to zend-console
 
 > ### Deprecated
-> Both the zend-console an the [zend-mvc-console](https://docs.zendframework.com/zend-mvc-console/) components will likely not be maintained long-term, as there are more complete implementations available elsewhere. We strongly urge developers to start migrating their console tooling to use other libraries, such as [symfony/console](https://github.com/symfony/console).
+> Both the zend-console and the [zend-mvc-console](https://docs.zendframework.com/zend-mvc-console/) components will likely not be maintained long-term, as there are more complete implementations available elsewhere. We strongly urge developers to start migrating their console tooling to use other libraries, such as [symfony/console](https://github.com/symfony/console).
 
 zend-console provides both generic support for routable console applications, as
 well as the basis for adding console support to zend-mvc-based applications.

--- a/docs/book/mvc/routing.md
+++ b/docs/book/mvc/routing.md
@@ -1,8 +1,5 @@
 # MVC Routing
 
-## Deprecated
-For MVC routing zend-console is dependent on [zend-mvc-console](https://docs.zendframework.com/zend-mvc-console/) which will not be maintained long term. We strongly urge developers to start migrating their MVC-based console tooling to use other libraries, such as [zf-console](https://github.com/zfcampus/zf-console) from [Zend Framework Campus](https://github.com/zfcampus).
-
 zend-mvc provides integration with zend-console, routing command line arguments
 to the appropriate action controller and action method that will handle the
 request. Actions can perform any number of tasks prior to returning a result to

--- a/docs/book/mvc/routing.md
+++ b/docs/book/mvc/routing.md
@@ -1,5 +1,8 @@
 # MVC Routing
 
+## Deprecated
+For MVC routing zend-console is dependent on [zend-mvc-console](https://docs.zendframework.com/zend-mvc-console/) which will not be maintained long term. We strongly urge developers to start migrating their MVC-based console tooling to use other libraries, such as [zf-console](https://github.com/zfcampus/zf-console) from [Zend Framework Campus](https://github.com/zfcampus).
+
 zend-mvc provides integration with zend-console, routing command line arguments
 to the appropriate action controller and action method that will handle the
 request. Actions can perform any number of tasks prior to returning a result to


### PR DESCRIPTION
Missing infos:
* For MVC Routing zend-console needs zend-mvc-console
* zend-mvc-console is deprecated!
See also:
https://github.com/zendframework/zend-console/issues/34

