### PR TITLE
Actually use result of array_unique

### DIFF
--- a/src/RouteMatcher/DefaultRouteMatcher.php
+++ b/src/RouteMatcher/DefaultRouteMatcher.php
@@ -305,7 +305,7 @@ class DefaultRouteMatcher implements RouteMatcherInterface
                 $options = preg_split('/ *\| */', trim($m['options']), 0, PREG_SPLIT_NO_EMPTY);
 
                 // remove dupes
-                array_unique($options);
+                $options = array_unique($options);
 
                 // prepare item
                 $item = [
@@ -343,7 +343,7 @@ class DefaultRouteMatcher implements RouteMatcherInterface
                 $options = preg_split('/ *\| */', trim($m['options']), 0, PREG_SPLIT_NO_EMPTY);
 
                 // remove dupes
-                array_unique($options);
+                $options = array_unique($options);
 
                 // prepare item
                 $item = [
@@ -381,7 +381,7 @@ class DefaultRouteMatcher implements RouteMatcherInterface
                 $options = preg_split('/ *\| */', trim($m['options']), 0, PREG_SPLIT_NO_EMPTY);
 
                 // remove dupes
-                array_unique($options);
+                $options = array_unique($options);
 
                 // remove prefix
                 array_walk($options, function (&$val) {
@@ -424,7 +424,7 @@ class DefaultRouteMatcher implements RouteMatcherInterface
                 $options = preg_split('/ *\| */', trim($m['options']), 0, PREG_SPLIT_NO_EMPTY);
 
                 // remove dupes
-                array_unique($options);
+                $options = array_unique($options);
 
                 // remove prefix
                 array_walk($options, function (&$val) {

--- a/test/RouteMatcher/DefaultRouteMatcherTest.php
+++ b/test/RouteMatcher/DefaultRouteMatcherTest.php
@@ -86,6 +86,15 @@ class DefaultRouteMatcherTest extends TestCase
                 ['--baz'],
                 null
             ],
+            'mandatory-long-flag-alternative-duplicates' => [
+                '(--foo | --foo | --bar)',
+                ['--foo'],
+                [
+                    'foo' => true,
+                    'bar' => false,
+                    'baz' => null,
+                ]
+            ],
 
             // -- mandatory short flags
             'mandatory-short-flag-no-match' => [
@@ -372,6 +381,11 @@ class DefaultRouteMatcherTest extends TestCase
             ],
             'mandatory-literal-namedAlternative-match-1' => [
                 'foo ( bar | baz ):altGroup',
+                ['foo','bar'],
+                ['foo' => null, 'altGroup' => 'bar', 'bar' => true, 'baz' => false]
+            ],
+            'mandatory-literal-namedAlternative-match-1-duplicates' => [
+                'foo ( bar | bar | baz ):altGroup',
                 ['foo','bar'],
                 ['foo' => null, 'altGroup' => 'bar', 'bar' => true, 'baz' => false]
             ],


### PR DESCRIPTION
This bug may have been harmless, the resulting regex built would have been
longer but functionally equivalent.

Add simple test that parsing options with duplicates
continues to succeed. (I didn't see any other tests of duplicates)

Fixes #43

Provide a narrative description of what you are trying to accomplish:

- [x] Are you fixing a bug? 
  - [ ] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior. (behavior seems to be equivalent to end users)
  - [ ] Base your feature on the `master` branch, and submit against that branch.
  - [ ] Add a regression test that demonstrates the bug, and proves the fix. (can't really do without accessing protected properties, which seems like a poor test)
  - [ ] Add a `CHANGELOG.md` entry for the fix.
